### PR TITLE
check: reverse madison output in list_versions

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -12,11 +12,11 @@ list_versions() {
   if [ -n "$version_pattern" ]; then
     filter="egrep ${version_pattern}"
   fi
-  apt-cache madison $package | awk '{print $3}' | $filter
+  apt-cache madison $package | awk '{print $3}' | $filter | tac
 }
 
 latest_version() {
-  list_versions | head -1
+  list_versions | tail -1
 }
 
 payload=$(mktemp /tmp/artifactory-deb.XXXXXX)


### PR DESCRIPTION
`apt-cache madison` emits versions newest-to-oldest (i.e. reverse
chronological order), and Concourse expects them to be emitted in
chronological order (i.e. the opposite).

Fixes #4